### PR TITLE
Fix passport-local

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -49,6 +49,7 @@ PassportConfigurator.prototype.setupModels = function (options) {
 /**
  * Initialize the passport configurator
  * @param {Boolean} noSession Set to true if no session is required
+ * @returns {Passport}
  */
 PassportConfigurator.prototype.init = function (noSession) {
   var self = this;
@@ -81,6 +82,8 @@ PassportConfigurator.prototype.init = function (noSession) {
       });
     });
   }
+  
+  return passport;
 }
 
 /**
@@ -147,6 +150,7 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
   var successRedirect = options.successRedirect || (link ? '/link/account' : '/auth/account');
   var failureRedirect = options.failureRedirect || (link ? '/link.html' : '/login.html');
   var scope = options.scope;
+  var authType = authScheme.toLowerCase();
 
   var session = !!options.session;
 
@@ -161,8 +165,8 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
       done(err, user, authInfo);
     };
   }
-
-  switch (authScheme.toLowerCase()) {
+  
+  switch (authType) {
     case 'local':
       passport.use(name, new AuthStrategy({
           usernameField: options.usernameField || 'username',
@@ -305,7 +309,15 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
    * Facebook will redirect the user back to the application at
    * /auth/facebook/callback with the authorization code
    */
-  if (link) {
+  if (authType === 'local') {
+    self.app.post(authPath, passport.authenticate(name, options.fn || {
+      successRedirect: options.successRedirect,
+      failureRedirect: options.failureRedirect,
+      successFlash: options.successFlash,
+      failureFlash: options.failureFlash,
+      scope: scope, session: session
+    }));
+  } else if (link) {
     self.app.get(authPath, passport.authorize(name, {scope: scope, session: session}));
   } else {
     self.app.get(authPath, passport.authenticate(name, {scope: scope, session: session}));


### PR DESCRIPTION
Correctly handle form POST credentials. Also, return the passport instance from init() in case the app needs this later.

Here's a basic provider config:

```
{
  "local-login": {
    "provider": "local",
    "module": "passport-local",
    "authPath": "/auth/local",
    "successRedirect": "/",
    "failureRedirect": "/",
    "session": true
  }
}
```
