### PR TITLE
Pass-through successReturnToOrRedirect option

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -311,6 +311,7 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
    */
   if (authType === 'local') {
     self.app.post(authPath, passport.authenticate(name, options.fn || {
+      successReturnToOrRedirect: options.successReturnToOrRedirect,
       successRedirect: options.successRedirect,
       failureRedirect: options.failureRedirect,
       successFlash: options.successFlash,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "passport": "~0.2.0"
   },
   "peerDependencies": {
-    "loopback": "1.x >=1.8.0"
+    "loopback": "2.x || 1.x >=1.8.0"
   },
   "devDependencies": {
     "loopback": "1.x >=1.8.0",


### PR DESCRIPTION
Another common option for passport-local - however, maybe we can abstract this in case other strategies need similar options (and POST verb support)?

Added `loopback 2.x to peerDependencies.
