### PR TITLE
use custom callbackPathHttpMethod

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -148,6 +148,7 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
   var callbackURL = options.callbackURL;
   var authPath = options.authPath || ((link ? '/link/' : '/auth/') + name);
   var callbackPath = options.callbackPath || ((link ? '/link/' : '/auth/') + name + '/callback');
+  var callbackPathHttpMethod = options.callbackPathHttpMethod || 'GET';
   var successRedirect = options.successRedirect || (link ? '/link/account' : '/auth/account');
   var failureRedirect = options.failureRedirect || (link ? '/link.html' : '/login.html');
   var scope = options.scope;
@@ -387,6 +388,9 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
     };
 
     // Register the path and the callback.
-    self.app.get(callbackPath, customCallback);
+    if (callbackPathHttpMethod === 'POST' )
+      self.app.post(callbackPath, customCallback);
+    else
+      self.app.get(callbackPath, customCallback);
   }
 };


### PR DESCRIPTION
When I logged in from a mobile app, In some cases It's necesary to use POST with the callbackPath

provider conf example
  "facebook-login-token": {
    "provider": "facebook",
    "module": "passport-facebook-token",
    "clientID": appConfig.facebookClientID,
    "clientSecret": appConfig.facebookClientSecret,
    "callbackPath": "/auth/facebook/callback-token",
    "scope": ["email"],
    "json": true,
    "callbackPathHttpMethod":"POST"
  },