### PR TITLE
Enable option for creating access token in conjunction with local login.

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -179,7 +179,7 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
       passport.use(name, new AuthStrategy(_.defaults({
           usernameField: options.usernameField || 'username',
           passwordField: options.passwordField || 'password',
-          session: options.session
+          session: options.session, authInfo: true
         }, options),
         function (username, password, done) {
           var query = {where: {or: [

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -191,29 +191,47 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
               return done(err);
             }
             if (user) {
-              user.hasPassword(password, function (err, ok) {
-                if (ok) {
-                  var u = user.toJSON();
-                  delete u.password;
-                  var userProfile = {
-                    provider: 'local',
-                    id: u.id,
-                    username: u.username,
-                    emails: [
-                      {
-                        value: u.email
-                      }
-                    ],
-                    status: u.status
-                  };
-                  done(null, userProfile);
+              var u = user.toJSON();
+              delete u.password;
+              var userProfile = {
+                provider: 'local',
+                id: u.id,
+                username: u.username,
+                emails: [
+                  {
+                    value: u.email
+                  }
+                ],
+                status: u.status,
+                accessToken: null
+              };
 
-                } else {
-                  return done(null, false, { message: 'Incorrect password.' });
-                }
-              });
+              // If we need a token as well, authenticate using Loopbacks
+              // own login system, else defer to a simple password check
+              if (options.setAccessToken) {
+                self.userModel.login({username: username, password: password},
+                    function (err, accessToken) {
+                      if (err) {
+                        return done(err);
+                      }
+                      if (accessToken) {
+                        userProfile.accessToken = accessToken;
+                        done(null, user, {accessToken: accessToken});
+                      } else {
+                        return done(null, false, {message: 'Failed to create token.'});
+                      }
+                    });
+              } else {
+                user.hasPassword(password, function (err, ok) {
+                  if (ok) {
+                    done(null, userProfile);
+                  } else {
+                    return done(null, false, {message: 'Incorrect password.'});
+                  }
+                });
+              }
             } else {
-              return done(null, false, { message: 'Incorrect username.' });
+              return done(null, false, {message: 'Incorrect username.'});
             }
           });
         }


### PR DESCRIPTION
This PR allows the creation of access tokens in conjunction with using the passport-local authentication strategy. This allows direct integration with the AngularJS SDK (although some hacking is still required on the client side to make it work).

To create a token while authenticating, the providers.json file needs to have the setAccessToken attribute set to true. For example:

```
{
  "local": {
    "provider": "local",
    "module": "passport-local",
    "usernameField": "username",
    "passwordField": "password",
    "authPath": "/auth/local",
    "setAccessToken": true
  }
}
```

If this is set, an access token will be available in the req of the authentication request:

```
app.post('/auth/local', function (req, res, next) {

  var day = 24 * 60 * 60 * 1000;
  res.cookie('access_token', req.authInfo.accessToken.id, {maxAge: day, signed: true});

  //....
});
```