### PR TITLE
username and email 

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -208,19 +208,33 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
 
               // If we need a token as well, authenticate using Loopbacks
               // own login system, else defer to a simple password check
+              //will grab user info from providers.json file.  Right now
+              //this only can use email and username, which are the 2 most common
               if (options.setAccessToken) {
-                self.userModel.login({username: username, password: password},
-                    function (err, accessToken) {
-                      if (err) {
-                        return done(err);
-                      }
-                      if (accessToken) {
-                        userProfile.accessToken = accessToken;
-                        done(null, user, {accessToken: accessToken});
-                      } else {
-                        return done(null, false, {message: 'Failed to create token.'});
-                      }
-                    });
+                switch(options.usernameField){
+                  case  'email':
+                    login({email: username, password: password});
+                    break;
+                  case 'username':
+                    login({username: username, password:password});
+                    break;
+                }
+
+                function login(creds){
+
+                  self.userModel.login(creds,
+                      function (err, accessToken) {
+                        if (err) {
+                          done(err);
+                        }
+                        if (accessToken) {
+                          userProfile.accessToken = accessToken;
+                          done(null, user, {accessToken: accessToken});
+                        } else {
+                          done(null, false, {message: 'Failed to create token.'});
+                        }
+                      });
+                }
               } else {
                 user.hasPassword(password, function (err, ok) {
                   if (ok) {


### PR DESCRIPTION
This is for the use of both username and email for `usernameField` when `setAccessToken:true`, and the User.login function is used.