### PR TITLE
support use of custom function for creating access token

### DIFF
--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -99,7 +99,7 @@
           return identity.user(function (err, user) {
             // Create access token if the autoLogin flag is set to true
             if(!err && user && autoLogin) {
-              return createAccessToken(user, function(err, token) {
+              return (options.createAccessToken || createAccessToken)(user, function(err, token) {
                 cb(err, user, identity, token);
               });
             }
@@ -134,7 +134,7 @@
           modified: date
         }, function (err, identity) {
           if(!err && user && autoLogin) {
-            return createAccessToken(user, function(err, token) {
+            return (options.createAccessToken || createAccessToken)(user, function(err, token) {
               cb(err, user, identity, token);
             });
           }


### PR DESCRIPTION
Application requiring this module can have usecases creating access token of specific format, not default format provided by this module.
For example, when this module is used with loopback-component-oauth2, UserIdentity.login needs to create a token as specific format used in loopback-component-oauth2.