### PR TITLE
ldap authentication

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -381,6 +381,9 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
           return next(err);
         }
         if (!user) {
+	  if (!!options.json){
+	    return res.status(401).json("authentication error")
+	  }
           return res.redirect(failureRedirect);
         }
         if (session) {

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -48,7 +48,7 @@ PassportConfigurator.prototype.setupModels = function (options) {
   if (!this.userIdentityModel.relations.user) {
     this.userIdentityModel.belongsTo(this.userModel, {as: 'user'});
   }
-
+ 
   if (!this.userCredentialModel.relations.user) {
     this.userCredentialModel.belongsTo(this.userModel, {as: 'user'});
   }
@@ -175,6 +175,34 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
   };
 
   switch (authType) {
+    case 'ldap': 
+      passport.use(name, new AuthStrategy(_.defaults({
+          usernameField: options.usernameField || 'username',
+          passwordField: options.passwordField || 'password',
+          session: options.session, authInfo: true,
+          passReqToCallback: true
+        }, options),
+        function (req, user, done) {
+	  if (user) {
+            // set user.id to ldap login
+            user.id = user[options.ldap_attribute_for_login || 'uid'];
+            var ldap_attribute_for_username = options.ldap_attribute_for_username || 'cn'
+            var ldap_attribute_for_mail = options.ldap_attribute_for_mail || 'mail'
+            var profile = { username: [].concat(user[ldap_attribute_for_username])[0]}
+            var email = [].concat(user[ldap_attribute_for_mail])[0]
+            if (!!email) {
+	      profile.emails = [{value: email}] 
+            }
+            var options_for_creation = _.defaults({
+              autoLogin: true
+	    },options)
+	    self.userIdentityModel.login(name, authScheme, profile, {}, 
+                                         options_for_creation, loginCallback(req,done))
+          }
+	  else { done(null)}
+	}
+      ));
+      break;
     case 'local':
       passport.use(name, new AuthStrategy(_.defaults({
           usernameField: options.usernameField || 'username',
@@ -344,6 +372,47 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
       ));
   }
 
+  var defaultCallback = function (req, res, next) {
+      // The default callback
+      passport.authenticate(name, _.defaults({session: session}, options.authOptions), function (err, user, info) {
+        if (err) {
+          return next(err);
+        }
+        if (!user) {
+          return res.redirect(failureRedirect);
+        }
+        if (session) {
+          req.logIn(user, function (err) {
+	             if (err) {
+              return next(err);
+            }
+            if (info && info.accessToken) {
+              if (!!options.json) {
+                return res.json({'access_token': info.accessToken.id, userId: user.id});
+              } else {
+                res.cookie('access_token', info.accessToken.id, 
+	          { signed: req.signedCookies ? true : false,maxAge: info.accessToken.ttl });
+                res.cookie('userId', user.id.toString(), { signed: req.signedCookies ? true : false,
+                  maxAge: info.accessToken.ttl });
+              }
+            }
+            return res.redirect(successRedirect);
+          });
+        } else {
+          if (info && info.accessToken) {
+            if (!!options.json) {
+              return res.json({'access_token': info.accessToken.id, userId: user.id});
+            } else {
+              res.cookie('access_token', info.accessToken.id, { signed: req.signedCookies ? true : false,
+                maxAge: info.accessToken.ttl });
+              res.cookie('userId', user.id.toString(), { signed: req.signedCookies ? true : false,
+                maxAge: info.accessToken.ttl });
+            }
+          }
+          return res.redirect(successRedirect);
+        }
+      })(req, res, next);
+    };
   /*
    * Redirect the user to Facebook for authentication.  When complete,
    * Facebook will redirect the user back to the application at
@@ -358,6 +427,9 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
       failureFlash: options.failureFlash,
       scope: scope, session: session
     }, options.authOptions)));
+  }  else if (authType === 'ldap') {
+    var ldapCallback = options.customCallback || defaultCallback;
+    self.app.post(authPath, ldapCallback)
   } else if (link) {
     self.app.get(authPath, passport.authorize(name, _.defaults({scope: scope, session: session}, options.authOptions)));
   } else {
@@ -383,48 +455,7 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
         res.redirect(failureRedirect);
       });
   } else {
-    var customCallback = options.customCallback || function (req, res, next) {
-      // The default callback
-      passport.authenticate(name, _.defaults({session: session}, options.authOptions), function (err, user, info) {
-        if (err) {
-          return next(err);
-        }
-        if (!user) {
-          return res.redirect(failureRedirect);
-        }
-        if (session) {
-          req.logIn(user, function (err) {
-            if (err) {
-              return next(err);
-            }
-            if (info && info.accessToken) {
-              if (!!options.json) {
-                return res.json({'access_token': info.accessToken.id, userId: user.id});
-              } else {
-                res.cookie('access_token', info.accessToken.id, { signed: req.signedCookies ? true : false,
-                  maxAge: 1000 * info.accessToken.ttl });
-                res.cookie('userId', user.id.toString(), { signed: req.signedCookies ? true : false,
-                  maxAge: 1000 * info.accessToken.ttl });
-              }
-            }
-            return res.redirect(successRedirect);
-          });
-        } else {
-          if (info && info.accessToken) {
-            if (!!options.json) {
-              return res.json({'access_token': info.accessToken.id, userId: user.id});
-            } else {
-              res.cookie('access_token', info.accessToken.id, { signed: req.signedCookies ? true : false,
-                maxAge: 1000 * info.accessToken.ttl });
-              res.cookie('userId', user.id.toString(), { signed: req.signedCookies ? true : false,
-                maxAge: 1000 * info.accessToken.ttl });
-            }
-          }
-          return res.redirect(successRedirect);
-        }
-      })(req, res, next);
-    };
-
+    var customCallback = options.customCallback || defaultCallback;
     // Register the path and the callback.
     self.app.get(callbackPath, customCallback);
   }

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -184,20 +184,22 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
         }, options),
         function (req, user, done) {
 	  if (user) {
-            // set user.id to ldap login
-            user.id = user[options.ldap_attribute_for_login || 'uid'];
-            var ldap_attribute_for_username = options.ldap_attribute_for_username || 'cn'
-            var ldap_attribute_for_mail = options.ldap_attribute_for_mail || 'mail'
-            var profile = { username: [].concat(user[ldap_attribute_for_username])[0]}
-            var email = [].concat(user[ldap_attribute_for_mail])[0]
+            var LdapAttributeForUsername = options.LdapAttributeForUsername || 'cn'
+            var LdapAttributeForMail = options.LdapAttributeForMail || 'mail'
+            var externalId = user[options.LdapAttributeForLogin || 'uid'];
+            var email = [].concat(user[LdapAttributeForMail])[0]
+            var profile = { 
+              username: [].concat(user[LdapAttributeForUsername])[0],
+              id: externalId
+            }
             if (!!email) {
 	      profile.emails = [{value: email}] 
             }
-            var options_for_creation = _.defaults({
+            var OptionsForCreation = _.defaults({
               autoLogin: true
 	    },options)
 	    self.userIdentityModel.login(name, authScheme, profile, {}, 
-                                         options_for_creation, loginCallback(req,done))
+                                         OptionsForCreation, loginCallback(req,done))
           }
 	  else { done(null)}
 	}


### PR DESCRIPTION
This pull request adds ldap authentication (with passport-ldapauth).

Remark : I moved the declaration of the default callback in order to use it.

Here is a configuration sample: 
```
  "myldap": {
	  "provider": "ldap",
	  "authScheme":"ldap",
	  "module": "passport-ldapauth",
	  "authPath": "/auth/ldap",
    "successRedirect": "/auth/account",
    "failureRedirect": "/ldap",
    "session": true,
    "ldap_attribute_for_login": "uid",
    "ldap_attribute_for_username": "uid",
    "ldap_attribute_for_mail": "mail",
	  "server":{
	    "url": "ldap://ldap.example.org:389/dc=example,dc=org",
	    "searchBase": "ou=people,dc=example,dc=org",
      "searchAttributes": ["cn", "mail", "uid", "givenname"],
	    "searchFilter": "(uid={{username}})"
	  }
  }
```