### PR TITLE
change callback to fit userModel.login behaviour 

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -225,7 +225,8 @@ PassportConfigurator.prototype.configureProvider = function (name, options) {
                   self.userModel.login(creds,
                       function (err, accessToken) {
                         if (err) {
-                          done(err);
+                          done(null, false, err);
+                          return
                         }
                         if (accessToken) {
                           userProfile.accessToken = accessToken;


### PR DESCRIPTION
Hi all,

userModel.login() calls the callback with the same err parameter on both technical problems as well as authorization Issues. As the most common reason for failure is most likely an authorization problem, I changed the call to passports done() accordingly (this way the HTTP status 401 and not a 500 will be returned on failed login attempts)

Also, done() is called twice currently. This PR should also fix that.

PS: I couldn't sign the CLA as I currently cant login to https://cla.strongloop.com/ - please consider this as my agreement to the terms stated on   https://cla.strongloop.com/agreements/strongloop/loopback-component-passport