### PR TITLE
feature: add dynamic querystring in `authpath`

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -510,7 +510,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
     self.app.post(authPath, ldapCallback)
   } else {
     self.app.get(authPath, function(req, res, next) {
-      var func = link ? passport.authorize : passport.authenticate;
+      var func = (link ? passport.authorize : passport.authenticate).bind(passport);
       func(name, _.defaults({
         state: encodeURIComponent(req._parsedOriginalUrl.search || ''),
         scope: scope,

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -1,5 +1,6 @@
 var loopback = require('loopback');
 var passport = require('passport');
+var url = require('url');
 var _ = require('underscore');
 
 module.exports = PassportConfigurator;
@@ -172,15 +173,19 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
   var callbackHTTPMethod = options.callbackHTTPMethod !== 'post' ? 'get' : 'post';
     
   // remember returnTo position, set by ensureLoggedIn
-  var successRedirect = function(req){
-    if (!!req && req.session && req.session.returnTo){    
-      var returnTo = req.session.returnTo;
+  var successRedirect = function(req) {
+    var returnTo;
+    if (!!req && req.session && req.session.returnTo) {    
+      returnTo = req.session.returnTo;
       delete req.session.returnTo;   
-      return returnTo;
+    } else {
+      returnTo = options.successRedirect ||
+        (link ? '/link/account' : '/auth/account');
     }
-    return options.successRedirect ||
-      (link ? '/link/account' : '/auth/account');    
-  }    
+    var urlObj = url.parse(returnTo, true);
+    urlObj.query.state = req.query.state;
+    return url.format(urlObj);
+  }
   
   var failureRedirect = options.failureRedirect ||
     (link ? '/link.html' : '/login.html');
@@ -503,16 +508,15 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
   } else if (authType === 'ldap') {
     var ldapCallback = options.customCallback || defaultCallback;
     self.app.post(authPath, ldapCallback)
-  } else if (link) {
-    self.app.get(authPath, passport.authorize(name, _.defaults({
-      scope: scope,
-      session: session
-    }, options.authOptions)));
   } else {
-    self.app.get(authPath, passport.authenticate(name, _.defaults({
-      scope: scope,
-      session: session
-    }, options.authOptions)));
+    self.app.get(authPath, function(req, res, next) {
+      var func = link ? passport.authorize : passport.authenticate;
+      func(name, _.defaults({
+        state: encodeURIComponent(req._parsedOriginalUrl.search || ''),
+        scope: scope,
+        session: session
+      }, options.authOptions))(req, res, next);
+    });
   }
 
   /*


### PR DESCRIPTION
Hi I occurred a case that I need a way to pass the `req.search` from `/auth/{provider}` to the final `successRedirect`, but I failed in your current codebase. Hence, I add this feature by `state`.

/cc @raymondfeng 
