### PR TITLE
Run passport in the correct middleware-phase

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -63,10 +63,10 @@ PassportConfigurator.prototype.setupModels = function(options) {
  */
 PassportConfigurator.prototype.init = function(noSession) {
   var self = this;
-  self.app.use(passport.initialize());
+  self.app.middleware('session', passport.initialize());
 
   if (!noSession) {
-    self.app.use(passport.session());
+    self.app.middleware('session', passport.session());
 
     // Serialization and deserialization is only required if passport session is
     // enabled


### PR DESCRIPTION
This change makes passport run in the `session` phase, instead of `routes` which is the default for `app.use`.
This allows for other middlewares that run before the `route` phase to access the user's session data (namely `req.user`).

See http://docs.strongloop.com/display/public/LB/Defining+middleware for details.