### PR TITLE
compatible with wechat's openid

### DIFF
--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -87,6 +87,7 @@
     }
     var autoLogin = options.autoLogin || options.autoLogin === undefined;
     var userIdentityModel = utils.getModel(this, UserIdentity);
+    profile.id = profile.id || profile.openid;
     userIdentityModel.findOne({where: {
       provider: provider,
       externalId: profile.id


### PR DESCRIPTION
Hey, I'm integrating the `wechat` with loopback and passport, but found all the coming profiles will replace the current `UserIdentity` which caused the `UserIdentity` always has 1 document.

That's because wechat doesn't return the `id` in its profil, then `externalId` will be empty always, and wechat is using a special `openid` at http://admin.wechat.com/wiki/index.php?title=User_Profile_via_Web, do you mind that we compatible with wechat in this repo? Because I didn't find somewhere that I can land the fix in other wechat-related repos like `passport-wechat`.