### PR TITLE
Customize cookie for use with subdomain

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -438,11 +438,13 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                 {
                   signed: req.signedCookies ? true : false,
                   // maxAge is in ms
-                  maxAge: 1000 * info.accessToken.ttl
+                  maxAge: 1000 * info.accessToken.ttl,
+                  domain: (options.domain) ? options.domain : null
                 });
               res.cookie('userId', user.id.toString(), {
                 signed: req.signedCookies ? true : false,
-                maxAge: 1000 * info.accessToken.ttl
+                maxAge: 1000 * info.accessToken.ttl,
+                domain: (options.domain) ? options.domain : null
               });
             }
           }


### PR DESCRIPTION
#74 Add an option to set cookie domain.

```javascript
{
  "facebook-login": {
     "provider": "facebook",
     "module": "passport-facebook",
     "clientID": "{facebook-client-id-1}",
     "clientSecret": "{facebook-client-secret-1}",
     "scope": ["email"]
     ...
    // Cookie domain
     "domain": ".mydomain.com"
   }  
  ...
}
```