### PR TITLE
adding dynamic redirect after successful login

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -169,8 +169,15 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
   var authPath = options.authPath || ((link ? '/link/' : '/auth/') + name);
   var callbackPath = options.callbackPath || ((link ? '/link/' : '/auth/') +
     name + '/callback');
-  var successRedirect = options.successRedirect ||
-    (link ? '/link/account' : '/auth/account');
+    
+  // remember returnTo position, set by ensureLoggedIn
+  var successRedirect = function(req){
+    if (req && req.session && req.session.returnTo)
+      return req.session.returnTo;    
+    return options.successRedirect ||
+      (link ? '/link/account' : '/auth/account');    
+  }    
+  
   var failureRedirect = options.failureRedirect ||
     (link ? '/link.html' : '/login.html');
   var scope = options.scope;
@@ -446,7 +453,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
               });
             }
           }
-          return res.redirect(successRedirect);
+          return res.redirect(successRedirect(req));
         });
       } else {
         if (info && info.accessToken) {
@@ -466,7 +473,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
             });
           }
         }
-        return res.redirect(successRedirect);
+        return res.redirect(successRedirect(req));
       }
     })(req, res, next);
   };
@@ -510,12 +517,12 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
     self.app.get(callbackPath, passport.authorize(name, _.defaults({
         session: session,
         // successReturnToOrRedirect: successRedirect,
-        successRedirect: successRedirect,
+        successRedirect: successRedirect(),
         failureRedirect: failureRedirect
       }, options.authOptions)),
       // passport.authorize doesn't handle redirect
       function(req, res, next) {
-        res.redirect(successRedirect);
+        res.redirect(successRedirect(req));
       }, function(err, req, res, next) {
         res.redirect(failureRedirect);
       });


### PR DESCRIPTION
Issue #60 (Stay at current page after login) fixed, using ensureLoggedIn's session.returnTo variable. If it's not set it falls back to the original.