### PR TITLE
JSON output changed to more closely match the output of /users/login.

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -440,10 +440,8 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           }
           if (info && info.accessToken) {
             if (!!options.json) {
-              return res.json({
-                'access_token': info.accessToken.id,
-                userId: user.id
-              });
+              info.accessToken.user = user;
+              return res.json(info.accessToken);
             } else {
               res.cookie('access_token', info.accessToken.id,
                 {
@@ -464,10 +462,8 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       } else {
         if (info && info.accessToken) {
           if (!!options.json) {
-            return res.json({
-              'access_token': info.accessToken.id,
-              userId: user.id
-            });
+            info.accessToken.user = user;
+            return res.json(info.accessToken);
           } else {
             res.cookie('access_token', info.accessToken.id, {
               signed: req.signedCookies ? true : false,


### PR DESCRIPTION
In /users/login, the entire accessToken object is returned, optionally with the user included as a property. It seems appropriate in loopback-component-passport to do the same, especially since I think a key issue currently is the confusing difference between this component and the operation of the rest of the API.
