### PR TITLE
Avoid duplicate user identities

### DIFF
--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -136,7 +136,7 @@
           return cb(err);
         }
         var date = new Date();
-        userIdentityModel.create({
+        userIdentityModel.findOrCreate({ where: { externalId: profile.id } }, {
           provider: provider,
           externalId: profile.id,
           authScheme: authScheme,


### PR DESCRIPTION
If a user try to login twice within a very short time, the server may receive requests almost the same time (due to bad network, maybe). loopback will create duplicate identities for a same user.

This patch will avoid duplicate user identities in such case, **only if the connector supports optimized `findOrCreate`**.

Signed-off-by: Clark Wang <clark.wangs@gmail.com>