### PR TITLE
provider name can be configured in options

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -163,6 +163,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       authScheme = 'local';
     }
   }
+  var provider = options.provider || name;
   var clientID = options.clientID;
   var clientSecret = options.clientSecret;
   var callbackURL = options.callbackURL;
@@ -218,14 +219,14 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
             var profile = {
               username: [].concat(user[LdapAttributeForUsername])[0],
               id: externalId
-            }
+            };
             if (!!email) {
               profile.emails = [{value: email}]
             }
             var OptionsForCreation = _.defaults({
               autoLogin: true
-            }, options)
-            self.userIdentityModel.login(name, authScheme, profile, {},
+            }, options);
+            self.userIdentityModel.login(provider, authScheme, profile, {},
               OptionsForCreation, loginCallback(req, done))
           }
           else {
@@ -327,13 +328,13 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           if (link) {
             if (req.user) {
               self.userCredentialModel.link(
-                req.user.id, name, authScheme, profile,
+                req.user.id, provider, authScheme, profile,
                 {token: token, tokenSecret: tokenSecret}, options, done);
             } else {
               done('No user is logged in');
             }
           } else {
-            self.userIdentityModel.login(name, authScheme, profile,
+            self.userIdentityModel.login(provider, authScheme, profile,
               {
                 token: token,
                 tokenSecret: tokenSecret
@@ -353,13 +354,13 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           if (link) {
             if (req.user) {
               self.userCredentialModel.link(
-                req.user.id, name, authScheme, profile,
+                req.user.id, provider, authScheme, profile,
                 {identifier: identifier}, options, done);
             } else {
               done('No user is logged in');
             }
           } else {
-            self.userIdentityModel.login(name, authScheme, profile,
+            self.userIdentityModel.login(provider, authScheme, profile,
               {identifier: identifier}, options, loginCallback(req, done));
           }
         }
@@ -376,7 +377,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           if (link) {
             if (req.user) {
               self.userCredentialModel.link(
-                req.user.id, name, authScheme, profile,
+                req.user.id, provider, authScheme, profile,
                 {
                   accessToken: accessToken,
                   refreshToken: refreshToken
@@ -385,7 +386,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
               done('No user is logged in');
             }
           } else {
-            self.userIdentityModel.login(name, authScheme, profile,
+            self.userIdentityModel.login(provider, authScheme, profile,
               {accessToken: accessToken, refreshToken: refreshToken},
               options, loginCallback(req, done));
           }
@@ -403,7 +404,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           if (link) {
             if (req.user) {
               self.userCredentialModel.link(
-                req.user.id, name, authScheme, profile,
+                req.user.id, provider, authScheme, profile,
                 {
                   accessToken: accessToken,
                   refreshToken: refreshToken
@@ -412,7 +413,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
               done('No user is logged in');
             }
           } else {
-            self.userIdentityModel.login(name, authScheme, profile,
+            self.userIdentityModel.login(provider, authScheme, profile,
               {accessToken: accessToken, refreshToken: refreshToken},
               options, loginCallback(req, done));
           }


### PR DESCRIPTION
[Wechat](http://weixin.qq.com) has three different endpoints for oauth 2.0 login, they may use different clientID and scope, so they have to be configured separately. And, wechat uses an `unionid` to identify a user cross different endpoints, so `loopback-component-passport` has to consider them as one provider.

Currently, `name` option is used for both provider name and strategy name. This PR add an optional `provider` to the config.

```
{
  "weixin-login": {
    "name": "weixin",
    "authScheme": "oAuth 2.0",
    "module": "passport-weixin",
    "clientID": "aaa",
    "clientSecret": "aaa",
    "scope": "snsapi_base",
    "autoLogin": true,
    "session": false,
    "domain": "example.com"
  },
  "weixin-user-login": {
    "name": "weixin-user",
    "provider": "weixin",
    "authScheme": "oAuth 2.0",
    "module": "passport-weixin",
    "clientID": "bbb",
    "clientSecret": "bbb",
    "scope": "snsapi_userinfo",
    "autoLogin": true,
    "session": false,
    "domain": "example.com"
  },
  "weixin-qr-login": {
    "name": "weixin-qr",
    "provider": "weixin",
    "authScheme": "oAuth 2.0",
    "module": "passport-weixin",
    "clientID": "ccc",
    "clientSecret": "ccc",
    "scope": "snsapi_login",
    "autoLogin": true,
    "session": false,
    "domain": "example.com"
  }
}
```

Signed-off-by: Clark Wang <clark.wangs@gmail.com>