### PR TITLE
Throw softer error in `local` strategy ...

### DIFF
--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -123,14 +123,17 @@
       }
 
       var query;
-      if (userObj.email) {
+      if (userObj.email && userObj.username) {
         query = { or: [
           { username: userObj.username },
           { email: userObj.email }
         ]};
+      } else if (userObj.email) {
+        query = { email: userObj.email };
       } else {
         query = { username: userObj.username };
       }
+
       userModel.findOrCreate({ where: query }, userObj, function (err, user) {
         if (err) {
           return cb(err);

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -288,7 +288,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                   self.userModel.login(creds,
                     function(err, accessToken) {
                       if (err) {
-                        return done(err);
+                        return err.code === 'LOGIN_FAILED'
+                            ? done(null, false, {message: 'Login failed'})
+                            : done(err);
                       }
                       if (accessToken) {
                         userProfile.accessToken = accessToken;


### PR DESCRIPTION
Throw softer error in `local` strategy when trying to create `accessToken` with `"setAccessToken": true` option. In case when reason is wrong user password.