### PR TITLE
Fix getting AuthStrategy directly from package when Strategy key is n…

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -147,6 +147,10 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
   options = options || {};
   var link = options.link;
   var AuthStrategy = require(options.module)[options.strategy || 'Strategy'];
+  
+  if (!AuthStrategy) {
+    AuthStrategy = require(options.module);
+  }
 
   var authScheme = options.authScheme;
   if (!authScheme) {
@@ -170,18 +174,18 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
   var callbackPath = options.callbackPath || ((link ? '/link/' : '/auth/') +
     name + '/callback');
   var callbackHTTPMethod = options.callbackHTTPMethod !== 'post' ? 'get' : 'post';
-    
+
   // remember returnTo position, set by ensureLoggedIn
   var successRedirect = function(req){
-    if (!!req && req.session && req.session.returnTo){    
+    if (!!req && req.session && req.session.returnTo){
       var returnTo = req.session.returnTo;
-      delete req.session.returnTo;   
+      delete req.session.returnTo;
       return returnTo;
     }
     return options.successRedirect ||
-      (link ? '/link/account' : '/auth/account');    
-  }    
-  
+      (link ? '/link/account' : '/auth/account');
+  }
+
   var failureRedirect = options.failureRedirect ||
     (link ? '/link.html' : '/login.html');
   var scope = options.scope;
@@ -304,8 +308,8 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                 // Fail to login if email is not verified or invalid username/password.
                 // Unify error message in order not to give indication about the error source for
                 // security purposes.
-                if (ok && user.emailVerified) 
-                  return done(null, userProfile); 
+                if (ok && user.emailVerified)
+                  return done(null, userProfile);
 
                 done(null, false, {message: errorMsg});
               });


### PR DESCRIPTION
Fix getting AuthStrategy directly from package when Strategy key is not here

See #83 for example with passport-facebook-token wich export Strategy directly without pass it through the "Stragtegy" attribute