### PR TITLE
Add cookieDomain option for configuration

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -463,12 +463,12 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                     signed: req.signedCookies ? true : false,
                   // maxAge is in ms
                     maxAge: 1000 * info.accessToken.ttl,
-                    domain: options.cookieDomain || options.domain || null
+                    domain:  typeof options.cookieDomain !== 'undefined' ? options.cookieDomain : (options.domain || null)
                   });
                 res.cookie('userId', user.id.toString(), {
                   signed: req.signedCookies ? true : false,
                   maxAge: 1000 * info.accessToken.ttl,
-                  domain: options.cookieDomain || options.domain || null
+                  domain:  typeof options.cookieDomain !== 'undefined' ? options.cookieDomain : (options.domain || null)
                 });
               }
             }

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -463,12 +463,12 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                     signed: req.signedCookies ? true : false,
                   // maxAge is in ms
                     maxAge: 1000 * info.accessToken.ttl,
-                    domain: (options.domain) ? options.domain : null,
+                    domain: options.cookieDomain || options.domain || null
                   });
                 res.cookie('userId', user.id.toString(), {
                   signed: req.signedCookies ? true : false,
                   maxAge: 1000 * info.accessToken.ttl,
-                  domain: (options.domain) ? options.domain : null,
+                  domain: options.cookieDomain || options.domain || null
                 });
               }
             }


### PR DESCRIPTION
In response to #129, add a `cookieDomain` option which has higher precedence than `domain`, since the auth0 passport strategy uses `domain` as a configuration option.

This allows explicitly defining `cookieDomain` as an option, while maintaining compatibility with existing configurations.
