### PR TITLE
Allow success redirect with access token in query parameter

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -463,12 +463,12 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                     signed: req.signedCookies ? true : false,
                   // maxAge is in ms
                     maxAge: 1000 * info.accessToken.ttl,
-                    domain: options.cookieDomain || options.domain || null
+                    domain:  typeof options.cookieDomain !== 'undefined' ? options.cookieDomain : (options.domain || null)
                   });
                 res.cookie('userId', user.id.toString(), {
                   signed: req.signedCookies ? true : false,
                   maxAge: 1000 * info.accessToken.ttl,
-                  domain: options.cookieDomain || options.domain || null
+                  domain:  typeof options.cookieDomain !== 'undefined' ? options.cookieDomain : (options.domain || null)
                 });
               }
             }

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -472,7 +472,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                 });
               }
             }
-            return res.redirect(successRedirect(req));
+            return res.redirect(successRedirect(req) + (options.redirectWithToken ? '?access_token=' + info.accessToken.id : ''));
           });
         } else {
           if (info && info.accessToken) {
@@ -492,7 +492,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
               });
             }
           }
-          return res.redirect(successRedirect(req));
+          return res.redirect(successRedirect(req) + (options.redirectWithToken ? '?access_token=' + info.accessToken.id : ''));
         }
       })(req, res, next);
   };

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -463,12 +463,12 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                     signed: req.signedCookies ? true : false,
                   // maxAge is in ms
                     maxAge: 1000 * info.accessToken.ttl,
-                    domain: (options.domain) ? options.domain : null,
+                    domain: options.cookieDomain || options.domain || null
                   });
                 res.cookie('userId', user.id.toString(), {
                   signed: req.signedCookies ? true : false,
                   maxAge: 1000 * info.accessToken.ttl,
-                  domain: (options.domain) ? options.domain : null,
+                  domain: options.cookieDomain || options.domain || null
                 });
               }
             }


### PR DESCRIPTION
Added an option for appending the access token as a query parameter on the success redirect URL. Similar to this [fork](https://github.com/asvdw/loopback-component-passport/commit/300579dd4b3157352b98eea831276cff890fb627), but with a config option `redirectWithToken`.

This was desired due to loopback-component-passport 3rd party login only supporting access token setting via cookies, which isn't feasible when the front-end and API are on different domains.

Similar in intent to #102, but it allows continued usage of the `returnTo` query parameter and is useful for apps that may have dynamic redirects on separate domains.