### PR TITLE
Standardized json access token response

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -463,7 +463,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
             if (info && info.accessToken) {
               if (!!options.json) {
                 return res.json({
-                  'access_token': info.accessToken.id,
+                  id: info.accessToken.id,
+                  ttl: info.accessToken.ttl,
+                  created: info.accessToken.created,
                   userId: user.id,
                 });
               } else {

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -489,8 +489,10 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           if (info && info.accessToken) {
             if (!!options.json) {
               return res.json({
-                'access_token': info.accessToken.id,
-                userId: user.id,
+                id: info.accessToken.id,
+                  ttl: info.accessToken.ttl,
+                  created: info.accessToken.created,
+                  userId: user.id,
               });
             } else {
               res.cookie('access_token', info.accessToken.id, {

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -490,9 +490,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
             if (!!options.json) {
               return res.json({
                 id: info.accessToken.id,
-                  ttl: info.accessToken.ttl,
-                  created: info.accessToken.created,
-                  userId: user.id,
+                ttl: info.accessToken.ttl,
+                created: info.accessToken.created,
+                userId: user.id,
               });
             } else {
               res.cookie('access_token', info.accessToken.id, {


### PR DESCRIPTION
### Description

Get the same response through `loopback-component-passport` as you get from signing in a user through standard Loopback login.

Wondering whether to leave an `access_token` field so as to not make this a breaking change.