### PR TITLE
Fix engines field back to "node >=4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "loopback-component-passport",
   "description": "LoopBack passport integration to support third party logins and account linking",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "keywords": [
     "StrongLoop",


### PR DESCRIPTION
Support for v0.10/v0.12 was accidentally added by 1d662c7e

The version 3.0.0 was released with `package.json` containing  two `engines` fields, the first entry specifying `node >= 0.10` and the second entry `node >= 4`. The version 3.1.0 "fixed" the engine field to specify `node >= 0.10` only.

@raymondfeng @superkhau what's your take on this change?  Technically, this is SEMVER-MAJOR, as we are dropping support for (some) Node versions again. Practically, I don't think anybody cares now.