### PR TITLE
Fix Azure Active Directory B2C support

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -397,6 +397,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
         passReqToCallback: true,
       }, options),
         function(req, accessToken, refreshToken, profile, done) {
+          profile.id = profile.id || profile.oid;
           if (link) {
             if (req.user) {
               self.userCredentialModel.link(


### PR DESCRIPTION
### Description
Fix Azure Active Directory B2C returning profile.oid instead of profile.id in response callback for openid-connect strategy

#### Related issues
#212 

### Checklist

- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
