### PR TITLE
Ability to set custom SAML id field

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -421,6 +421,8 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
         passReqToCallback: true,
       }, options),
         function(req, profile, done) {
+        console.log(profile);
+        
           if (link) {
             if (req.user) {
               self.userCredentialModel.link(req.user.id, name, authScheme,

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -421,6 +421,12 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
         passReqToCallback: true,
       }, options),
         function(req, profile, done) {
+          console.log(profile);
+
+          if (!profile.id && options.samlExternalId && profile[options.samlExternalId]) {
+           profile.id = profile[options.samlExternalId];
+          }
+        
         console.log(profile);
         
           if (link) {

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -421,13 +421,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
         passReqToCallback: true,
       }, options),
         function(req, profile, done) {
-          console.log(profile);
-
           if (!profile.id && options.samlExternalId && profile[options.samlExternalId]) {
            profile.id = profile[options.samlExternalId];
           }
-        
-        console.log(profile);
         
           if (link) {
             if (req.user) {


### PR DESCRIPTION
### Description
Sometimes SAML idProvider doesn't return a proper "id" field.
This PR gives us a way to choose the field acting as id, with samlExternalId option


### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
