### PR TITLE
Add LDAP properties configuration

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -106,6 +106,37 @@ PassportConfigurator.prototype.init = function(noSession) {
 };
 
 /**
+ * Build a user profile based on user's ldap attributes and a mapping definition
+ * @private
+ * @param {Object} user The user's attributes from ldap
+ * @param {Object} options Ldap provider options, with mapping definition in
+ * options.profileAttributesFromLDAP
+ * @return {Object} user profile
+ * @end
+ */
+PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
+  var profile = {};
+  for (var profileAttributeName in options.profileAttributesFromLDAP) {
+    var LdapAttributeName = options.profileAttributesFromLDAP[profileAttributeName];
+    profile[profileAttributeName] = [].concat(user[LdapAttributeName])[0];
+  }
+  // If missing, add profile attributes required by UserIdentity Model
+  if (!profile.username) {
+    profile.username = [].concat(user['cn'])[0];
+  }
+  if (!profile.id) {
+    profile.id = user['uid'];
+  }
+  if (!profile.emails) {
+    var email = [].concat(user['mail'])[0];
+    if (!!email) {
+      profile.emails = [{value: email}];
+    }
+  }
+  return profile;
+};
+
+/**
  * Configure a Passport strategy provider.
  * @param {String} name The provider name
  * @options {Object} General&nbsp;Options Options for the auth provider.
@@ -233,17 +264,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       }, options),
         function(req, user, done) {
           if (user) {
-            var LdapAttributeForUsername = options.LdapAttributeForUsername || 'cn';
-            var LdapAttributeForMail = options.LdapAttributeForMail || 'mail';
-            var externalId = user[options.LdapAttributeForLogin || 'uid'];
-            var email = [].concat(user[LdapAttributeForMail])[0];
-            var profile = {
-              username: [].concat(user[LdapAttributeForUsername])[0],
-              id: externalId,
-            };
-            if (!!email) {
-              profile.emails = [{value: email}];
-            }
+            var profile = self.buildUserLdapProfile(user, options);
             var OptionsForCreation = _.defaults({
               autoLogin: true,
             }, options);

--- a/test/passport-configurator.test.js
+++ b/test/passport-configurator.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+var m = require('./init');
+var loopback = require('loopback');
+var assert = require('assert');
+var UserIdentity = m.UserIdentity;
+var User = loopback.User;
+var UserCredential = m.UserCredential;
+var PassportConfigurator = m.PassportConfigurator;
+var app = loopback();
+var passportConfigurator = new PassportConfigurator(app);
+
+before(destoyAllUsers);
+
+describe('PassportConfigurator', function() {
+  before(setupModels);
+
+  it('supports user ldap profile configuration with all minimal config',
+  function(done) {
+    var providerConfig = {
+      ldap: {
+        provider: 'ldap',
+        authScheme: 'ldap',
+        module: 'passport-ldapauth',
+        authPath: '/auth/ldap',
+        successRedirect: '/auth/account',
+        failureRedirect: '/ldap',
+        session: true,
+        failureFlash: true,
+        profileAttributesFromLDAP: {
+          login: 'uid',
+          username: 'uid',
+          displayName: 'displayName',
+          email: 'mail',
+          externalId: 'uid',
+          id: 'uid',
+        },
+      },
+    };
+
+    /* user's ldap attributes */
+    var userFromLdap = {
+      uid: 'john-doe-uid',
+      displayName: 'John Doe',
+      mail: 'john.doe@somewhere.sw',
+    };
+    var profile = passportConfigurator.buildUserLdapProfile(userFromLdap, providerConfig.ldap);
+
+    assert.equal(profile.login, userFromLdap.uid, '"login" should take value of "uid"');
+    assert.equal(profile.username, userFromLdap.uid, '"username" should take value of "uid"');
+    assert.equal(profile.displayName, userFromLdap.displayName,
+      '"displayName" should take value of "displayName"');
+    assert.equal(profile.email, userFromLdap.mail, '"email" should take value of "mail"');
+    assert.deepEqual(profile.emails, [{value: userFromLdap.mail}],
+      '"emails" should be comptued from "mail"');
+    assert.equal(profile.externalId, userFromLdap.uid, '"externalId" should take value of "uid"');
+    done();
+  });
+
+  it('supports user ldap profile configuration with missing ldap mapping configuration',
+  function(done) {
+    var providerConfig = {
+      ldap: {
+        provider: 'ldap',
+        authScheme: 'ldap',
+        module: 'passport-ldapauth',
+        authPath: '/auth/ldap',
+        successRedirect: '/auth/account',
+        failureRedirect: '/ldap',
+        session: true,
+        failureFlash: true,
+        profileAttributesFromLDAP: {
+          // empty mapping
+        },
+      },
+    };
+
+    /* user's ldap attributes */
+    var userFromLdap = {
+      cn: 'John Doe',
+      uid: 'john-doe-uid',
+      displayName: 'John Doe',
+      mail: 'john.doe@somewhere.sw',
+    };
+    var profile = passportConfigurator.buildUserLdapProfile(userFromLdap, providerConfig.ldap);
+
+    // 3 ldap attributes are required in profile: username, emails, id.
+    // They should be present even if not defiend in Ldap mapping, set to default Ldap attributes
+    assert.equal(profile.username, userFromLdap.cn, '"username" should take value of "cn"');
+    assert.deepEqual(profile.emails, [{value: userFromLdap.mail}],
+      '"emails" should be comptued from "mail"');
+    assert.equal(profile.id, userFromLdap.uid, '"id" should take value of "uid"');
+    done();
+  });
+
+  function setupModels() {
+    var ds = loopback.createDataSource({
+      connector: 'memory',
+    });
+
+    UserIdentity.attachTo(ds);
+    User.attachTo(ds);
+    UserIdentity.belongsTo(User);
+
+    passportConfigurator.init();
+    passportConfigurator.setupModels({
+      userModel: User,
+      userIdentityModel: UserIdentity,
+      userCredentialModel: UserCredential,
+    });
+  }
+});
+
+function destoyAllUsers(done) {
+  User.destroyAll(done);
+}


### PR DESCRIPTION
In replacement of PR #108 that is now too hard to merge.

### Description

This pull request adds a way to configure the LDAP properties we want in the user profile.
The configuration is to be defined in providers.json config file.
It defines a binding between a user profile property name and a LDAP property name.
Bellow is an exemple of 'ldap' provider configuration.

```
  "ldap": {
    "provider": "ldap",
    "authScheme":"ldap",
    "module": "passport-ldapauth",
    "authPath": "/auth/ldap",
    "successRedirect": "/auth/account",
    "failureRedirect": "/ldap",
    "session": true,
    "failureFlash": true,
    "profileAttributesFromLDAP": {
      "login": "uid",
      "username": "uid",
      "displayName": "displayName",
      "email": "mail",
      "externalId": "uid"
    },
    "server":{
      "url": "ldap://ldap-server:134",
      "searchBase": "dc=domain,dc=fr",
      "searchFilter": "(cn={{username}})"
    }
  },
```

In this example, after a successful authentication, the `user.profile` json object will contains the following properties:

```
  login: <value of ldap property 'uid'>
  username: <value of ldap property 'uid'>
  displayName: <value of ldap property 'displayName'>
  email: <value of ldap property 'mail'>
  externalId: <value of ldap property 'uid'>
```

Please note I submit a pull request on loopback-example-passport to include an example with ldap using this feature: strongloop/loopback-example-passport#54

#### Related issues

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)