### PR TITLE
Fix local strategy and mixed username fields (ie username OR password)

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -313,14 +313,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                   });
               };
               if (options.setAccessToken) {
-                switch (options.usernameField) {
-                  case  'email':
-                    login({email: username, password: password});
-                    break;
-                  case 'username':
-                    login({username: username, password: password});
-                    break;
-                }
+                login({username: userProfile.username, password: password});
               } else {
                 return user.hasPassword(password, function(err, ok) {
                   // Fail to login if email is not verified or invalid username/password.


### PR DESCRIPTION
### Description

When using locale authentication, cookies were never set.

#### Related issues

- #57 and related PR https://github.com/strongloop/loopback-component-passport/pull/88
- #220 

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)