### PR TITLE
Add support for option to append access_token and userid to successRedirect

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -490,6 +490,30 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
   passport.use(name, strategy);
 
   var defaultCallback = function(req, res, next) {
+    var completeAuth = function(user, info){
+      if (info && info.accessToken) {
+        if (!!options.json) {
+          return res.json({
+            'access_token': info.accessToken.id,
+            userId: user.id,
+          });
+        } else {
+          res.cookie('access_token', info.accessToken.id,
+            {
+              signed: req.signedCookies ? true : false,
+              // maxAge is in ms
+              maxAge: 1000 * info.accessToken.ttl,
+              domain: (options.domain) ? options.domain : null,
+            });
+          res.cookie('userId', user.id.toString(), {
+            signed: req.signedCookies ? true : false,
+            maxAge: 1000 * info.accessToken.ttl,
+            domain: (options.domain) ? options.domain : null,
+          });
+        }
+      }
+    };
+
     // The default callback
     passport.authenticate(name, _.defaults({session: session},
       options.authOptions), function(err, user, info) {
@@ -505,54 +529,20 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           }
           return res.redirect(failureRedirect);
         }
+
         if (session) {
           req.logIn(user, function(err) {
             if (err) {
               return next(err);
             }
-            if (info && info.accessToken) {
-              if (!!options.json) {
-                return res.json({
-                  'access_token': info.accessToken.id,
-                  userId: user.id,
-                });
-              } else {
-                res.cookie('access_token', info.accessToken.id,
-                  {
-                    signed: req.signedCookies ? true : false,
-                  // maxAge is in ms
-                    maxAge: 1000 * info.accessToken.ttl,
-                    domain: (options.domain) ? options.domain : null,
-                  });
-                res.cookie('userId', user.id.toString(), {
-                  signed: req.signedCookies ? true : false,
-                  maxAge: 1000 * info.accessToken.ttl,
-                  domain: (options.domain) ? options.domain : null,
-                });
-              }
-            }
+            completeAuth(user, info);
             return res.redirect(successRedirect(req));
           });
         } else {
-          if (info && info.accessToken) {
-            if (!!options.json) {
-              return res.json({
-                'access_token': info.accessToken.id,
-                userId: user.id,
-              });
-            } else {
-              res.cookie('access_token', info.accessToken.id, {
-                signed: req.signedCookies ? true : false,
-                maxAge: 1000 * info.accessToken.ttl,
-              });
-              res.cookie('userId', user.id.toString(), {
-                signed: req.signedCookies ? true : false,
-                maxAge: 1000 * info.accessToken.ttl,
-              });
-            }
-          }
+          completeAuth(user, info);
           return res.redirect(successRedirect(req, info.accessToken));
         }
+
       })(req, res, next);
   };
   /*!

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -144,6 +144,7 @@ PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
  * @property {Boolean} link Set to true if the provider is for third-party
  * account linking.
  * @property {Object} module The passport strategy module from require.
+ * @property {Boolean} appendAccessToken Append The access_token and userid to the successRedirect URL as query params.
  * @property {String} authScheme The authentication scheme, such as 'local',
  * 'oAuth 2.0'.
  * @property {Boolean} [session] Set to true if session is required.  Valid
@@ -511,6 +512,8 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
             domain: (options.domain) ? options.domain : null,
           });
         }
+
+        return res.redirect(successRedirect(req, options.appendAccessToken && info.accessToken));
       }
     };
 
@@ -536,11 +539,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
               return next(err);
             }
             completeAuth(user, info);
-            return res.redirect(successRedirect(req));
           });
         } else {
           completeAuth(user, info);
-          return res.redirect(successRedirect(req, info.accessToken));
         }
 
       })(req, res, next);

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -10,6 +10,7 @@ var g = SG();
 
 var loopback = require('loopback');
 var passport = require('passport');
+var URL = require('url');
 var _ = require('underscore');
 
 module.exports = PassportConfigurator;
@@ -231,7 +232,15 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
     if (!accessToken) {
       return url;
     }
-    return url + '?access-token=' + accessToken.id + '&user-id=' + accessToken.userId;
+
+    var urlObj = URL.parse(url, true);
+    urlObj.search = null;
+    urlObj.query = Object.assign({}, urlObj.query, {
+      'access-token': accessToken.id,
+      'user-id': accessToken.userId
+    });
+
+    return URL.format(urlObj);
   };
 
   var failureRedirect = options.failureRedirect ||


### PR DESCRIPTION
### Description
Addresses several open issues with adding support for optionally appending the access_token and userid to the `successRedirect` Url. This is particularly useful when supporting iOS native clients/hybrid applications. In current implementation, it is only possible when `options.session !== true`.

Also, DRYs up common logic in the `defaultCallback`, while adding universal support for the `options.domain` cookie property.

If these changes are agreeable, I will append this PR with updated tests.


#### Related issues
- #167 (nested functions)
- #14 (I think?)
- #102 
- #157
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
