### PR TITLE
Enable custom callback for local auth strategy and email verification

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -559,7 +559,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
    * Setup the authentication request URLs.
    */
   if (authType === 'local') {
-    self.app.post(authPath, passport.authenticate(
+    var localCallback = options.customCallback || passport.authenticate(
       name, options.fn || _.defaults({
         successReturnToOrRedirect: options.successReturnToOrRedirect,
         successRedirect: options.successRedirect,
@@ -567,7 +567,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
         successFlash: options.successFlash,
         failureFlash: options.failureFlash,
         scope: scope, session: session,
-      }, options.authOptions)));
+      }, options.authOptions)
+    );
+    self.app.post(authPath, localCallback);
   } else if (authType === 'ldap') {
     var ldapCallback = options.customCallback || defaultCallback;
     self.app.post(authPath, ldapCallback);

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -323,7 +323,11 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                           done(null, false, {message: g.f('Failed to create token.')}) :
                           done(err);
                     }
-                    if (accessToken && user.emailVerified) {
+
+                    var emailVerification = typeof options.emailVerificationCallback === 'function' ?
+                      options.emailVerificationCallback(user) : user.emailVerified;
+
+                    if (accessToken && emailVerification) {
                       userProfile.accessToken = accessToken;
                       done(null, userProfile, {accessToken: accessToken});
                     } else {


### PR DESCRIPTION
### Description

- Enable custom callback for local auth strategy (Example https://gist.github.com/michaelfreund/edc147f1abefb39753496856306aa076)

- Enable custom callback for local auth email verification (Example https://gist.github.com/michaelfreund/412091675d36a04eb0dfdbb0c8d22ec6)

#### Related issues

- connect to strongloop/loopback-component-passport/issues/57
- connect to strongloop/loopback-component-passport/issues/161

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
