### PR TITLE
Upd: saml: pass callbackURL as callbackUrl. [REBASED]

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -442,6 +442,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       break;
     case 'saml':
       strategy = new AuthStrategy(_.defaults({
+        callbackUrl: callbackURL,
         passReqToCallback: true,
       }, options),
         function(req, profile, done) {


### PR DESCRIPTION
### Description

As specified in the [`passport-saml`](https://github.com/bergie/passport-saml/) package, the callback URL should be passed as `callbackUrl` which is different from all passport strategies. To avoid such discrepancies, defaults the `callbackUrl` to the given `callbackURL`. In any case, it will not break compatibility as it will be overridden by `callbackUrl` if it is already specified.


> `callbackUrl`: full `callbackUrl` (overrides path/protocol if supplied)
`path`: path to callback; will be combined with protocol and server host information to construct callback url if `callbackUrl` is not specified (default: `/saml/consume`)
`protocol`: protocol for callback; will be combined with `path` and server `host` information to construct callback url if `callbackUrl` is not specified (default: `http://`)
`host`: host for callback; will be combined with `path` and `protocol` to construct callback url if `callbackUrl` is not specified (default: `localhost`)

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
