### PR TITLE
add a configuration for cookieOptions

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -505,6 +505,13 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           }
           return res.redirect(failureRedirect);
         }
+        var cookieOptions = typeof options.cookieOptions === 'function' ?
+          options.cookieOptions(req, res, info, user) :
+          _.defaults(options.cookieOptions, {
+            signed: req.signedCookies ? true : false,
+            // maxAge is in ms
+            maxAge: 1000 * info.accessToken.ttl,
+          });
         if (session) {
           req.logIn(user, function(err) {
             if (err) {
@@ -517,18 +524,8 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                   userId: user.id,
                 });
               } else {
-                res.cookie('access_token', info.accessToken.id,
-                  {
-                    signed: req.signedCookies ? true : false,
-                  // maxAge is in ms
-                    maxAge: 1000 * info.accessToken.ttl,
-                    domain: (options.domain) ? options.domain : null,
-                  });
-                res.cookie('userId', user.id.toString(), {
-                  signed: req.signedCookies ? true : false,
-                  maxAge: 1000 * info.accessToken.ttl,
-                  domain: (options.domain) ? options.domain : null,
-                });
+                res.cookie('access_token', info.accessToken.id, cookieOptions);
+                res.cookie('userId', user.id.toString(), cookieOptions);
               }
             }
             return res.redirect(successRedirect(req));
@@ -541,14 +538,8 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                 userId: user.id,
               });
             } else {
-              res.cookie('access_token', info.accessToken.id, {
-                signed: req.signedCookies ? true : false,
-                maxAge: 1000 * info.accessToken.ttl,
-              });
-              res.cookie('userId', user.id.toString(), {
-                signed: req.signedCookies ? true : false,
-                maxAge: 1000 * info.accessToken.ttl,
-              });
+              res.cookie('access_token', info.accessToken.id, cookieOptions);
+              res.cookie('userId', user.id.toString(), cookieOptions);
             }
           }
           return res.redirect(successRedirect(req, info.accessToken));


### PR DESCRIPTION
### Description

options.cookieOptions can either be a function or an object, the result is passed to [res.cookie ](http://expressjs.com/en/api.html#res.cookie) as the options argument.

Please advise the tests I should include, because I don't see any testing the existing configuration options for anything other than the ldap provider. I am happy to add something similar for the local login provider if somebody could help me with a minimal configuration and guidance of what other tests to add.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
