### PR TITLE
Add group search support for LDAP Authentication

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -117,7 +117,12 @@ PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
   var profile = {};
   for (var profileAttributeName in options.profileAttributesFromLDAP) {
     var LdapAttributeName = options.profileAttributesFromLDAP[profileAttributeName];
-    profile[profileAttributeName] = [].concat(user[LdapAttributeName])[0];
+    // support groupSearch results
+    if (LdapAttributeName === '_groups') {
+      profile[profileAttributeName] = [].concat(user[LdapAttributeName]);
+    } else {
+      profile[profileAttributeName] = [].concat(user[LdapAttributeName])[0];
+    }
   }
   // If missing, add profile attributes required by UserIdentity Model
   if (!profile.username) {

--- a/test/passport-configurator.test.js
+++ b/test/passport-configurator.test.js
@@ -52,7 +52,7 @@ describe('PassportConfigurator', function() {
       '"displayName" should take value of "displayName"');
     assert.equal(profile.email, userFromLdap.mail, '"email" should take value of "mail"');
     assert.deepEqual(profile.emails, [{value: userFromLdap.mail}],
-      '"emails" should be comptued from "mail"');
+      '"emails" should be computed from "mail"');
     assert.equal(profile.externalId, userFromLdap.uid, '"externalId" should take value of "uid"');
     done();
   });
@@ -90,6 +90,55 @@ describe('PassportConfigurator', function() {
     assert.deepEqual(profile.emails, [{value: userFromLdap.mail}],
       '"emails" should be comptued from "mail"');
     assert.equal(profile.id, userFromLdap.uid, '"id" should take value of "uid"');
+    done();
+  });
+
+  it('supports user ldap profile configuration with group search',
+  function(done) {
+    var providerConfig = {
+      ldap: {
+        provider: 'ldap',
+        authScheme: 'ldap',
+        module: 'passport-ldapauth',
+        authPath: '/auth/ldap',
+        successRedirect: '/auth/account',
+        failureRedirect: '/ldap',
+        session: true,
+        failureFlash: true,
+        profileAttributesFromLDAP: {
+          login: 'uid',
+          username: 'uid',
+          displayName: 'displayName',
+          email: 'mail',
+          externalId: 'uid',
+          id: 'uid',
+          groups: '_groups',
+        },
+      },
+    };
+
+    /* user's ldap attributes */
+    var userFromLdap = {
+      uid: 'john-doe-uid',
+      displayName: 'John Doe',
+      mail: 'john.doe@somewhere.sw',
+      _groups: [
+        {dn: 'cn=PortalAdmins,o=greenwell', controls: []},
+        {dn: 'cn=ConnectionsAdmins,o=greenwell', controls: []},
+      ],
+    };
+    var profile = passportConfigurator.buildUserLdapProfile(userFromLdap, providerConfig.ldap);
+
+    assert.equal(profile.login, userFromLdap.uid, '"login" should take value of "uid"');
+    assert.equal(profile.username, userFromLdap.uid, '"username" should take value of "uid"');
+    assert.equal(profile.displayName, userFromLdap.displayName,
+      '"displayName" should take value of "displayName"');
+    assert.equal(profile.email, userFromLdap.mail, '"email" should take value of "mail"');
+    assert.deepEqual(profile.emails, [{value: userFromLdap.mail}],
+      '"emails" should be computed from "mail"');
+    assert.equal(profile.externalId, userFromLdap.uid, '"externalId" should take value of "uid"');
+    assert.deepEqual(profile.groups, userFromLdap._groups,
+      '"groups" should be computed from "_groups"');
     done();
   });
 


### PR DESCRIPTION
### Description
The used LDAP package `vesse/node-ldapauth-fork` supports [group search capabilities](https://github.com/vesse/node-ldapauth-fork#ldapauth-config-options). Once an authentication was successful an array of groups will be added to the user record.
Sample output with groups:
``` 
{ dn: 'uid=fadams,o=greenwell',
controls: [],
givenname: 'Frank',
uid: 'fadams',
cn: 'Frank Adams',
_groups:
[ { dn: 'cn=PortalAdmins,o=greenwell', controls: [] },
{ dn: 'cn=ConnectionsAdmins,o=greenwell', controls: [] } ] }
```

Currently only the first element of the `_groups` array is used by loopback.
Since `_groups` is a [hardcoded reference](https://github.com/vesse/node-ldapauth-fork/blob/master/lib/ldapauth.js#L323) in `node-ldapauth-fork` we can use the same hardcoded reference in our code.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
