### PR TITLE
Additional Support for SAML Auth

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -11,6 +11,7 @@ var g = SG();
 var loopback = require('loopback');
 var passport = require('passport');
 var _ = require('underscore');
+var fs = require('fs');
 var bytesToUuid = require('uuid/lib/bytesToUuid');
 
 module.exports = PassportConfigurator;
@@ -190,6 +191,15 @@ PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
  * For both oAuth 1 and 2.
  * @property {String} [failureRedirect] The redirect route if login fails.
  * For both oAuth 1 and 2.
+ *
+ * @options {Object} saml&nbsp;Options Options for SAML.
+ * @property {String} [callbackURL] saml callback URL.
+ * @property {String} [entryPoint] identity provider entrypoint.
+ * @property {String} [issuer] issuer string to supply to identity provider.
+ * @property {String} [audience] expected saml response Audience.
+ * @property {String} [certPath] path to public certificate for saml idp.
+ * @property {String} [privateCertPath] path to private key for encrypthing saml idp.
+ * @property {String} [decryptionPvkPath] path to optional private key that will be used to attempt to decrypt any encrypted assertions that are received.
  *
  * @options {Object} Local&nbsp;Strategy&nbsp;Options Options for local
  * strategy.
@@ -473,6 +483,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
     case 'saml':
       strategy = new AuthStrategy(_.defaults({
         callbackUrl: callbackURL,
+        cert: options.certPath ? fs.readFileSync(options.certPath, 'utf-8') : null,
+        privateCert: options.privateCertPath ? fs.readFileSync(options.privateCertPath, 'utf-8') : null,
+        decryptionPvk: options.decryptionPvkPath ? fs.readFileSync(options.decryptionPvkPath, 'utf-8') : null,
         passReqToCallback: true,
       }, options),
         function(req, profile, done) {

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -483,11 +483,11 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
     case 'saml':
       strategy = new AuthStrategy(_.defaults({
         callbackUrl: callbackURL,
-        cert: options.certPath ? fs.readFileSync(options.certPath, 'utf-8') : null,
+        cert: options.certPath ? fs.readFileSync(options.certPath, 'utf-8') : options.certPath,
         privateCert: options.privateCertPath ?
-          fs.readFileSync(options.privateCertPath, 'utf-8') : null,
+          fs.readFileSync(options.privateCertPath, 'utf-8') : options.privateCertPath,
         decryptionPvk: options.decryptionPvkPath ?
-          fs.readFileSync(options.decryptionPvkPath, 'utf-8') : null,
+          fs.readFileSync(options.decryptionPvkPath, 'utf-8') : options.decryptionPvkPath,
         passReqToCallback: true,
       }, options),
         function(req, profile, done) {

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -484,8 +484,10 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       strategy = new AuthStrategy(_.defaults({
         callbackUrl: callbackURL,
         cert: options.certPath ? fs.readFileSync(options.certPath, 'utf-8') : null,
-        privateCert: options.privateCertPath ? fs.readFileSync(options.privateCertPath, 'utf-8') : null,
-        decryptionPvk: options.decryptionPvkPath ? fs.readFileSync(options.decryptionPvkPath, 'utf-8') : null,
+        privateCert: options.privateCertPath ?
+          fs.readFileSync(options.privateCertPath, 'utf-8') : null,
+        decryptionPvk: options.decryptionPvkPath ?
+          fs.readFileSync(options.decryptionPvkPath, 'utf-8') : null,
         passReqToCallback: true,
       }, options),
         function(req, profile, done) {

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -483,11 +483,11 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
     case 'saml':
       strategy = new AuthStrategy(_.defaults({
         callbackUrl: callbackURL,
-        cert: options.certPath ? fs.readFileSync(options.certPath, 'utf-8') : options.certPath,
+        cert: options.certPath ? fs.readFileSync(options.certPath, 'utf-8') : options.cert,
         privateCert: options.privateCertPath ?
-          fs.readFileSync(options.privateCertPath, 'utf-8') : options.privateCertPath,
+          fs.readFileSync(options.privateCertPath, 'utf-8') : options.privateCert,
         decryptionPvk: options.decryptionPvkPath ?
-          fs.readFileSync(options.decryptionPvkPath, 'utf-8') : options.decryptionPvkPath,
+          fs.readFileSync(options.decryptionPvkPath, 'utf-8') : options.decryptionPvk,
         passReqToCallback: true,
       }, options),
         function(req, profile, done) {

--- a/test/configure-provider.test.js
+++ b/test/configure-provider.test.js
@@ -20,6 +20,7 @@ describe('configureProvider', function() {
   function OAuth2Strategy(options, verify) {};
   function OpenIDStrategy(options, verify) {};
   function OpenIDConnectStrategy(options, verify) {};
+  function SamlStrategy(options, verify) {};
 
   function testReturnType(Strategy, module, authScheme) {
     var options = {
@@ -41,6 +42,7 @@ describe('configureProvider', function() {
     mock('passport-oauth2', OAuth2Strategy);
     mock('passport-openid', OpenIDStrategy);
     mock('passport-openidconnect', OpenIDConnectStrategy);
+    mock('passport-saml', SamlStrategy);
   });
 
   it('returns an LDAPStrategy', function() {
@@ -65,5 +67,9 @@ describe('configureProvider', function() {
 
   it('returns an OpenIdConnectStrategy', function() {
     testReturnType(OpenIDConnectStrategy, 'passport-openidconnect', 'openid connect');
+  });
+
+  it('returns a SamlStrategy', function() {
+    testReturnType(SamlStrategy, 'passport-saml', 'saml');
   });
 });

--- a/test/configure-provider.test.js
+++ b/test/configure-provider.test.js
@@ -45,11 +45,11 @@ describe('configureProvider', function() {
     mock('passport-saml', SamlStrategy);
   });
 
-  it('returns an LDAPStrategy', function() {
+  it('returns a LDAPStrategy', function() {
     testReturnType(LDAPStrategy, 'passport-ldapauth', 'ldap');
   });
 
-  it('returns an LocalStrategy', function() {
+  it('returns a LocalStrategy', function() {
     testReturnType(LocalStrategy, 'passport-local', 'local');
   });
 


### PR DESCRIPTION
### Description
Added additional support for `saml` authentication:
- Documented required options of `passport-saml` in the function JSDoc
- Added `certPath`, `privateCertPath`, `decryptionPvkPath`, which allows passing paths to keys, rather than keys themselves.
- Added test to `configure-provider` for `saml`.
- Pedantic fixes to grammar of `mocha` tests (`an` -> `a`)

### Checklist
<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
