### PR TITLE
Add failureError Option

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -558,7 +558,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           if (options.failureQueryString && info) {
             return res.redirect(appendErrorToQueryString(failureRedirect, info));
           }
-          if(options.failureError){
+          if (options.failureError) {
             return next(new Error('authentication error'));
           }
           return res.redirect(failureRedirect);
@@ -674,8 +674,8 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
         if (options.failureQueryString) {
           return res.redirect(appendErrorToQueryString(failureRedirect, err));
         }
-      
-        if(options.failureError){
+
+        if (options.failureError) {
           return next(err);
         }
 

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -191,6 +191,8 @@ PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
  * For both oAuth 1 and 2.
  * @property {String} [failureRedirect] The redirect route if login fails.
  * For both oAuth 1 and 2.
+ * @property {Boolean} [failureQueryString] If true, appends the error message to the redirect.
+ * @property {Boolean} [failureError] If true, returns an error rather than redirecting gracefully.
  *
  * @options {Object} saml&nbsp;Options Options for SAML.
  * @property {String} [callbackURL] saml callback URL.
@@ -200,6 +202,10 @@ PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
  * @property {String} [certPath] path to public certificate for saml idp.
  * @property {String} [privateCertPath] path to private key for encrypthing saml idp.
  * @property {String} [decryptionPvkPath] path to optional private key that will be used to attempt to decrypt any encrypted assertions that are received.
+ * @property {String} [successRedirect] The redirect route if login succeeds.
+ * @property {String} [failureRedirect] The redirect route if login fails.
+ * @property {Boolean} [failureQueryString] If true, appends the error message to the redirect.
+ * @property {Boolean} [failureError] If true, returns an error rather than redirecting gracefully.
  *
  * @options {Object} Local&nbsp;Strategy&nbsp;Options Options for local
  * strategy.
@@ -215,6 +221,8 @@ PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
  * For both oAuth 1 and 2.
  * @property {String} [failureRedirect] The redirect route if login fails.
  * For both oAuth 1 and 2.
+ * @property {Boolean} [failureQueryString] If true, appends the error message to the redirect.
+ * @property {Boolean} [failureError] If true, returns an error rather than redirecting gracefully.
  *
  * @options {Object} OpenID&nbsp;Options Options for OpenID.
  * @property {String} [returnURL] OpenID return URL.

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -557,6 +557,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
           if (options.failureQueryString && info) {
             return res.redirect(appendErrorToQueryString(failureRedirect, info));
           }
+          if(options.failureError){
+            return next(new Error('authentication error'));
+          }
           return res.redirect(failureRedirect);
         }
         if (session) {

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -645,7 +645,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       }, function(err, req, res, next) {
         if (options.failureFlash) {
           if (typeof req.flash !== 'function') {
-            next(new TypeError(g.f('{{req.flash}} is not a function')));
+            return next(new TypeError(g.f('{{req.flash}} is not a function')));
           }
           var flash = options.failureFlash;
           if (typeof flash === 'string') {
@@ -664,7 +664,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
         }
       
         if(options.failureError){
-          next(err);
+          return next(err);
         }
 
         res.redirect(failureRedirect);

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -662,6 +662,10 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
         if (options.failureQueryString) {
           return res.redirect(appendErrorToQueryString(failureRedirect, err));
         }
+      
+        if(options.failureError){
+          next(err);
+        }
 
         res.redirect(failureRedirect);
       });

--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -179,6 +179,7 @@ PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
  * 'oAuth 2.0'.
  * @property {Boolean} [session] Set to true if session is required.  Valid
  * for any auth scheme.
+ * @property {Boolean} [signCookies] disables signing cookies (default: enabled)
  * @property {String} [authPath] Authentication route.
  *
  * @options {Object} oAuth2&nbsp;Options Options for oAuth 2.0.
@@ -576,13 +577,13 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
               } else {
                 res.cookie('access_token', info.accessToken.id,
                   {
-                    signed: req.signedCookies ? true : false,
+                    signed: options.signCookies != false && req.signedCookies ? true : false,
                   // maxAge is in ms
                     maxAge: 1000 * info.accessToken.ttl,
                     domain: (options.domain) ? options.domain : null,
                   });
                 res.cookie('userId', user.id.toString(), {
-                  signed: req.signedCookies ? true : false,
+                  signed: options.signCookies != false && req.signedCookies ? true : false,
                   maxAge: 1000 * info.accessToken.ttl,
                   domain: (options.domain) ? options.domain : null,
                 });
@@ -599,11 +600,11 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
               });
             } else {
               res.cookie('access_token', info.accessToken.id, {
-                signed: req.signedCookies ? true : false,
+                signed: options.signCookies != false && req.signedCookies ? true : false,
                 maxAge: 1000 * info.accessToken.ttl,
               });
               res.cookie('userId', user.id.toString(), {
-                signed: req.signedCookies ? true : false,
+                signed: options.signCookies != false && req.signedCookies ? true : false,
                 maxAge: 1000 * info.accessToken.ttl,
               });
             }


### PR DESCRIPTION
* Fixes header rewrite error.  Shouldn't continue processing middleware if redirect is set.
* Adds option `failureError` which fails with errors, rather than redirecting safely.
* Documents `failureError`, `failureRedirect` and `failureQueryString`.