### PR TITLE
3rd party re-login was not working using custom user models

### DIFF
--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -156,7 +156,16 @@ function UserIdentity(UserIdentity) {
             },
             function(err, i) {
               // Find the user for the given identity
-              return identity.user(function(err, user) {
+              // When using custom user models, the relation between Identity and User does not seem to work.
+              // Fetching the user model out of the identity.
+              if (err) {
+                cb(err, identity);
+              }
+              var userModel =
+                (userIdentityModel.relations.user &&
+                  userIdentityModel.relations.user.modelTo) ||
+                loopback.getModelByType(loopback.User);
+              userModel.findById(i.userId, function(err, user) {
                 // Create access token if the autoLogin flag is set to true
                 if (!err && user && autoLogin) {
                   return (options.createAccessToken || createAccessToken)(


### PR DESCRIPTION
### Description
While using a custom user model I ran into the problem, that on a 3rd party login with Azure AD the user identity model was not able to find the related user model.
Therefore a login was never successful.
Fixed by manually looking up the user in the related user model (custom or not) and using this user object.

#### Related issues
- kind of relates to #95 

### Checklist
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [styleguide](http://loopback.io/doc/en/contrib/style-guide.html)

Ran the NPM tests which were already included, as I didn't implement new things.
