### PR TITLE
support nameID as saml profile id field

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -492,7 +492,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
       }, options),
       function(req, profile, done) {
         // Azure saml profile returns http://schemas.microsoft.com/identity/claims/objectidentifier
-        profile.id = profile.id || profile['http://schemas.microsoft.com/identity/claims/objectidentifier'];
+        profile.id = profile.id || profile.nameID || profile['http://schemas.microsoft.com/identity/claims/objectidentifier'];
         if (link) {
           if (req.user) {
             self.userCredentialModel.link(req.user.id, name, authScheme,


### PR DESCRIPTION
I am not sure what saml strategies are supported here, but passport-saml uses a nameID field for the profile id as per the SAML specification.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
