### PR TITLE
#267 get all groups for ms-ad

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -142,7 +142,7 @@ PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
     }
 
     // support groupSearch results
-    if (ldapAttrName === '_groups') {
+    if (ldapAttrName === '_groups' || ldapAttrName === 'memberOf') {
       profile[profileAttrName] = [].concat(user[ldapAttrName]);
     } else {
       profile[profileAttrName] = [].concat(user[ldapAttrName])[0];

--- a/test/passport-configurator.test.js
+++ b/test/passport-configurator.test.js
@@ -147,6 +147,55 @@ describe('PassportConfigurator', function() {
       done();
     });
 
+  it('supports user ldap profile configuration with group search for microsoft active directory',
+    function(done) {
+      var providerConfig = {
+        ldap: {
+          provider: 'ldap',
+          authScheme: 'ldap',
+          module: 'passport-ldapauth',
+          authPath: '/auth/ldap',
+          successRedirect: '/auth/account',
+          failureRedirect: '/ldap',
+          session: true,
+          failureFlash: true,
+          profileAttributesFromLDAP: {
+            login: 'uid',
+            username: 'uid',
+            displayName: 'displayName',
+            email: 'mail',
+            externalId: 'uid',
+            id: 'uid',
+            groups: 'memberOf',
+          },
+        },
+      };
+
+      /* user's ldap attributes */
+      var userFromLdap = {
+        uid: 'john-doe-uid',
+        displayName: 'John Doe',
+        mail: 'john.doe@somewhere.sw',
+        memberOf: [
+          {dn: 'cn=PortalAdmins,o=greenwell', controls: []},
+          {dn: 'cn=ConnectionsAdmins,o=greenwell', controls: []},
+        ],
+      };
+      var profile = passportConfigurator.buildUserLdapProfile(userFromLdap, providerConfig.ldap);
+
+      assert.equal(profile.login, userFromLdap.uid, '"login" should take value of "uid"');
+      assert.equal(profile.username, userFromLdap.uid, '"username" should take value of "uid"');
+      assert.equal(profile.displayName, userFromLdap.displayName,
+        '"displayName" should take value of "displayName"');
+      assert.equal(profile.email, userFromLdap.mail, '"email" should take value of "mail"');
+      assert.deepEqual(profile.emails, [{value: userFromLdap.mail}],
+        '"emails" should be computed from "mail"');
+      assert.equal(profile.externalId, userFromLdap.uid, '"externalId" should take value of "uid"');
+      assert.deepEqual(profile.groups, userFromLdap.memberOf,
+        '"groups" should be computed from "memberOf"');
+      done();
+    });
+
   function setupModels() {
     var ds = loopback.createDataSource({
       connector: 'memory',


### PR DESCRIPTION
### Description

groupSearch results were based on the _groups ldap attribute and ignored the memberOf attribute which is traditionally used in Active Directory.  This fix makes sure both work.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #267

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
